### PR TITLE
Fake data

### DIFF
--- a/client/src/app/modules/auth/modules/employee/components/clients/clients/clients.component.html
+++ b/client/src/app/modules/auth/modules/employee/components/clients/clients/clients.component.html
@@ -27,7 +27,7 @@
       </ng-container>
       <ng-container matColumnDef="deliveryRouteId">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> DELIVERY ROUTE </th>
-        <td mat-cell *matCellDef="let row"> {{row.deliveryRoute.name}} </td>
+        <td mat-cell *matCellDef="let row"> {{row.deliveryRoute?.name}} </td>
       </ng-container>
       <ng-container matColumnDef="createdDate">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> CREATED </th>

--- a/common/models/client.js
+++ b/common/models/client.js
@@ -1,6 +1,8 @@
 'use strict';
 const appRoot = require('app-root-path');
+const debugMockData = require('debug')('order-manager:Client:mockData');
 const Promise = require('bluebird');
+const yn = require('yn');
 const _ = require('lodash');
 const app = require(appRoot + '/server/server');
 const metricSetting = require(appRoot + '/config/metric');
@@ -75,6 +77,68 @@ module.exports = function(Client) {
       const client2 = client.toJSON();
       return !_.isEmpty(client2.orders);
     });
+  };
+
+  /**
+   * create 5 mock clients. Mock clients have an email 'mockClient@etr.com'
+   * @returns {Client[]} - array of mock clients
+   */
+  Client.mockData = async function() {
+    if (!yn(process.env.CREATE_MOCK_DATA)) {
+      return [];
+    }
+    debugMockData('Client.mockData() - Begins');
+    let clients = [];
+    const MockEmail = 'mockClient@etr.com';
+    clients = await Client.find({ where: { email: MockEmail } });
+    if (clients.length === 0) {
+      const MockClients = [
+        {
+          name: 'Kenny Market',
+          addressStreet: '3508 W 3rd St.', addressCity: 'Los Angeles', addressState: 'CA', addressZip: '90020',
+          phone: '213-555-1111', email: MockEmail, contactPersonName: 'Kenny T. Ro', contactPersonPhone: '213-555-1112',
+          feeType: 'Rate', feeValue: 3.50, showPublic: false
+        },
+        {
+          name: 'Jose Food',
+          addressStreet: '928 S Western Ave #257.', addressCity: 'Los Angeles', addressState: 'CA', addressZip: '90006',
+          phone: '213-555-2222', email: MockEmail, contactPersonName: 'Jose Ro', contactPersonPhone: '213-555-2221',
+          feeType: 'Rate', feeValue: 4.50, showPublic: false
+        },
+        {
+          name: 'LA Grocery',
+          addressStreet: '2915 W Olympic Blvd.', addressCity: 'Los Angeles', addressState: 'CA', addressZip: '90006',
+          phone: '213-555-3333', email: MockEmail, contactPersonName: 'Kenny La', contactPersonPhone: '213-555-3332',
+          feeType: 'Fixed', feeValue: 100.00, showPublic: false
+        },
+        {
+          name: 'Kim\'s Dollar Store',
+          addressStreet: '3917 W 6th St.', addressCity: 'Los Angeles', addressState: 'CA', addressZip: '90020',
+          phone: '213-555-4444', email: MockEmail, contactPersonName: 'Lan Y. Kim', contactPersonPhone: '213-555-4442',
+          feeType: 'Rate', feeValue: 4.00, showPublic: false
+        },
+        {
+          name: 'USA Market',
+          addressStreet: '1471 W Jefferson Blvd.', addressCity: 'Los Angeles', addressState: 'CA', addressZip: '90007',
+          phone: '213-555-5551', email: MockEmail, contactPersonName: 'Steve Trump', contactPersonPhone: '213-555-5552',
+          feeType: 'Rate', feeValue: 5.50, showPublic: false
+        }
+      ];
+      try {
+        const routes = await app.models.DeliveryRoute.find();
+        MockClients.forEach(function(client, index) {
+          client.deliveryRouteId = routes[index % routes.length].id;
+        });
+        clients = await Client.create(MockClients);
+        clients.forEach(function(client) {
+          debugMockData(`<Client[${client.id}]>: Created new client`);
+        });
+      } catch (error) {
+        console.error(`Failed to create mock clients - ${error.message}`);
+      }
+    }
+    debugMockData('Client.mockData() - Ends');
+    return clients;
   };
 
   /**

--- a/common/models/order.js
+++ b/common/models/order.js
@@ -1,7 +1,9 @@
 'use strict';
 const appRoot = require('app-root-path');
+const debugMockData = require('debug')('order-manager:Order:mockData');
 const HttpErrors = require('http-errors');
 const Promise = require('bluebird');
+const yn = require('yn');
 const _ = require('lodash');
 const app = require(appRoot + '/server/server');
 const logger = require(appRoot + '/config/winston');
@@ -370,6 +372,78 @@ module.exports = function(Order) {
       logger.error(`Error while generating package distribution list pdf file - ${error.message}`);
       throw error;
     }
+  };
+
+  /**
+   * Mock orders for the given clients.
+   * @param{Client[]} clients - mock clients
+   */
+  Order.mockData = async function(clients) {
+    if (!yn(process.env.CREATE_MOCK_DATA)) {
+      return;
+    }
+    debugMockData('Order.mockData() - Begins');
+    if (clients.length === 0) {
+      return;
+    }
+    const adminUser = await app.models.EndUser.findOne({ where: { role: 'admin' } });
+    const metadata = { endUserId: adminUser.id };
+    let orders = await Order.find({
+      where: { and: [
+        { clientId: { inq: clients.map(c => c.id) } },
+        { status: { nin: ['Cancelled', 'Completed'] } }
+      ] }
+    });
+
+    if (orders.length === 0) {
+      try {
+        const products = await app.models.Product.find();
+        const createResult = await Promise.mapSeries(clients, async function(client) {
+          let orderItems = products.map(function(product) {
+            if (Math.random() < 0.5) {
+              return {
+                productId: product.id,
+                quantity: Math.floor(Math.random() * 10),
+                unitPrice: Number(product.unitPrice)
+              };
+            }
+          });
+          orderItems = _.compact(orderItems);
+          let subtotal = orderItems.reduce((a, c) => a += c.quantity * c.unitPrice, 0);
+          let fee = (client.feeType === 'Fixed') ? Number(client.feeValue) : subtotal * Number(client.feeValue);
+          let orderData = {
+            clientId: client.id,
+            status: 'Submitted',
+            subtotal: subtotal,
+            fee: fee,
+            totalAmount: subtotal + fee,
+            note: 'Mock data'
+          };
+          return await Order.createNew(orderData, orderItems, metadata);
+        });
+        orders = await Order.find({
+          where: { id: { inq: createResult.map(result => result.orderId) } }
+        });
+        orders.forEach(function(order) {
+          debugMockData(`<Client[${order.clientId}]>: Created new order(id: ${order.id})`);
+        });
+      } catch (error) {
+        console.error(`Error while creating mock orders - ${error.message}`);
+      }
+      return;
+    }
+
+    // update order status. 'Shipped' order updates its status via different API.
+    let shipped = _.remove(orders, function(order) { return order.status === 'Shipped'; });
+    await Promise.each(orders, async function(order) {
+      if (order.status === 'Submitted') {
+        await order.updateAttribute('status', 'Processed');
+      } else if (order.status === 'Processed') {
+        await order.updateAttribute('status', 'Shipped');
+      }
+    });
+    await Order.completeOrders(shipped.map(function(order) { return order.id; }), metadata);
+    debugMockData('Order.mockData() - Ends');
   };
 
   Order.prototype.getPdfName = function() {

--- a/common/models/order.json
+++ b/common/models/order.json
@@ -31,7 +31,7 @@
     "status": {
       "type": "string",
       "default": "Submitted",
-      "description": "'Submitted', 'Processed', 'Completed', or 'Cancelled'"
+      "description": "'Submitted', 'Processed', 'Shipped', 'Completed', or 'Cancelled'"
     },
     "subtotal": {
       "type": "number"

--- a/server/boot/scheduler.js
+++ b/server/boot/scheduler.js
@@ -1,8 +1,9 @@
 'use strict';
 const scheduler = require('node-schedule');
+const yn = require('yn');
 
 module.exports = function(app) {
-  if (process.env.ONE_OFF || !process.env.IS_WORKER) {
+  if (yn(process.env.ONE_OFF) || !yn(process.env.IS_WORKER)) {
     return;  // skip if it's one off process or not a worker.
   }
 
@@ -10,6 +11,14 @@ module.exports = function(app) {
   const everyMinRule = new scheduler.RecurrenceRule();
   everyMinRule.second = 0;
   scheduler.scheduleJob(everyMinRule, app.models.Metric.batchUpdate);
+
+  if (yn(process.env.CREATE_MOCK_DATA)) {
+    const mockRule = new scheduler.RecurrenceRule();
+    mockRule.hour = [8, 12, 18, 20];
+    mockRule.minute = 0;
+    mockRule.second = 30;
+    scheduler.scheduleJob(mockRule, app.models.Metric.mockData);
+  }
 
   // schedule jobs to run every midnight
   // const everyMidnightRule = new scheduler.RecurrenceRule();

--- a/server/boot/scheduler.js
+++ b/server/boot/scheduler.js
@@ -13,11 +13,21 @@ module.exports = function(app) {
   scheduler.scheduleJob(everyMinRule, app.models.Metric.batchUpdate);
 
   if (yn(process.env.CREATE_MOCK_DATA)) {
+    // schedule job to create mock data. This job runs 4 times everyday.
+    // 4 times are due to update order status to 4 different values.
     const mockRule = new scheduler.RecurrenceRule();
     mockRule.hour = [8, 12, 18, 20];
     mockRule.minute = 0;
     mockRule.second = 30;
     scheduler.scheduleJob(mockRule, app.models.Metric.mockData);
+
+    // schedule job to remove old mock data to run at 23:00 on Sunday.
+    const rmMockRule = new scheduler.RecurrenceRule();
+    rmMockRule.dayOfWeek = [0];
+    rmMockRule.hour = 23;
+    rmMockRule.minute = 0;
+    rmMockRule.second = 0;
+    scheduler.scheduleJob(rmMockRule, app.models.Metric.removeOldMockData);
   }
 
   // schedule jobs to run every midnight


### PR DESCRIPTION
This check-in addresses issue #58.
Schedule jobs to create/update mock data and to delete old mock data.
'CREATE_MOCK_DATA' environment variable enable/disable the jobs.
[NOTE] These feature should be used only in demo environment. 
Mock data are as follow:
- Update unit price of products daily.
- Create 5 mock clients if not present
- Create/update orders for mock clients daily except Sunday
- Create statement for mock clients weekly on Sunday.
- Delete product metric data and statements/orders that are 3 months old. This cleanup runs on every Sunday night.