### PR TITLE
Remove metric data of mock data.

### DIFF
--- a/common/models/statement.js
+++ b/common/models/statement.js
@@ -208,6 +208,11 @@ module.exports = function(Statement) {
     debugMockData('Statement.mockData() - Ends');
   };
 
+  /**
+   * Delete statements of the given clients older than the cutoff data.
+   * @param{Client[]} clients - mock clients
+   * @param{Date} cutOffDate - delete statement if older than this date.
+   */
   Statement.removeOldData = async function(clients, cutOffDate) {
     if (!yn(process.env.CREATE_MOCK_DATA)) {
       return;


### PR DESCRIPTION
Remove leaf level metric data of mock data if it's more than 7 days old. The removal is scheduled to run once a week.