### PR TITLE
Remove id token

### DIFF
--- a/client/src/app/modules/auth/modules/customer/services/data-api.service.ts
+++ b/client/src/app/modules/auth/modules/customer/services/data-api.service.ts
@@ -16,30 +16,22 @@ export class DataApiService {
   }
 
   find(modelName: string, filter: object = {}): Observable<any> {
-    return this._dataApi.genericFind(this._getIdToken(),
-      modelName, filter);
+    return this._dataApi.genericFind(modelName, filter);
   }
 
   findById(modelName: string, id: string, filter:object = {}): Observable<any> {
-    return this._dataApi.genericFindById(this._getIdToken(),
-      modelName, id, filter);
+    return this._dataApi.genericFindById(modelName, id, filter);
   }
 
   upsert(modelName: string, modelObj: object): Observable<any> {
-    return this._dataApi.genericUpsert(this._getIdToken(),
-      modelName, modelObj);
+    return this._dataApi.genericUpsert(modelName, modelObj);
   }
 
   destroyById(modelName: string, id: string): Observable<any> {
-    return this._dataApi.genericDestroyById(this._getIdToken(),
-      modelName, id);
+    return this._dataApi.genericDestroyById(modelName, id);
   }
 
   genericMethod(modelName: string, methodName: string, param?: Array<any>): Observable<any> {
-    return this._dataApi.genericMethod(this._getIdToken(), modelName, methodName, param || []);
-  }
-
-  private _getIdToken() {
-    return this._cookieService.get('idToken');
+    return this._dataApi.genericMethod(modelName, methodName, param || []);
   }
 }

--- a/client/src/app/modules/auth/modules/employee/services/data-api.service.ts
+++ b/client/src/app/modules/auth/modules/employee/services/data-api.service.ts
@@ -17,37 +17,29 @@ export class DataApiService {
   }
 
   find(modelName: string, filter: object = {}): Observable<any> {
-    return this._dataApi.genericFind(this._getIdToken(),
-      modelName, filter);
+    return this._dataApi.genericFind(modelName, filter);
   }
 
   findById(modelName: string, id: string, filter: object = {}): Observable<any> {
-    return this._dataApi.genericFindById(this._getIdToken(),
-      modelName, id, filter);
+    return this._dataApi.genericFindById(modelName, id, filter);
   }
 
   upsert(modelName: string, modelObj: object): Observable<any> {
-    return this._dataApi.genericUpsert(this._getIdToken(),
-      modelName, modelObj);
+    return this._dataApi.genericUpsert(modelName, modelObj);
   }
 
   destroyById(modelName: string, id: string): Observable<any> {
-    return this._dataApi.genericDestroyById(this._getIdToken(),
-      modelName, id);
+    return this._dataApi.genericDestroyById(modelName, id);
   }
 
   genericMethod(modelName: string, methodName: string, param?: Array<any>): Observable<any> {
-    return this._dataApi.genericMethod(this._getIdToken(), modelName, methodName, param || []);
+    return this._dataApi.genericMethod(modelName, methodName, param || []);
   }
 
   /*
    * This code is commented out because of response type not a json issue(See pdf.service.ts for detail)
   genericGetFile(modelName: string, methodName: string, param?: Array<any>): Observable<any> {
-    return this._dataApi.genericGetFile(this._getIdToken(), modelName, methodName, param || []);
+    return this._dataApi.genericGetFile(modelName, methodName, param || []);
   }
   */
-
-  private _getIdToken() {
-    return this._cookieService.get('idToken');
-  }  
 }

--- a/client/src/app/modules/auth/modules/employee/services/pdf.service.ts
+++ b/client/src/app/modules/auth/modules/employee/services/pdf.service.ts
@@ -23,7 +23,6 @@ export class PdfService {
     const headers = new HttpHeaders()
       .set('Accept', 'application/pdf');
     const httpParams = new HttpParams()
-      .set('idToken', this._cookieService.get('idToken'))
       .set('modelName', modelName)
       .set('methodName', methodName)
       .set('params', JSON.stringify(params));

--- a/client/src/app/shared/sdk/services/custom/CustomerData.ts
+++ b/client/src/app/shared/sdk/services/custom/CustomerData.ts
@@ -32,11 +32,11 @@ export class CustomerDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {object} filter 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object[]} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -47,14 +47,13 @@ export class CustomerDataApi extends BaseLoopBackApi {
    * This usually means the response is a `CustomerData` object.)
    * </em>
    */
-  public genericFind(idToken: any, modelName: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+  public genericFind(modelName: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "GET";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/CustomerData/find";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -66,13 +65,13 @@ export class CustomerDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {string} id 
    *
    * @param {object} filter 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -83,7 +82,7 @@ export class CustomerDataApi extends BaseLoopBackApi {
    * This usually means the response is a `CustomerData` object.)
    * </em>
    */
-  public genericFindById(idToken: any, modelName: any, id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+  public genericFindById(modelName: any, id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "GET";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/CustomerData/findById/:id";
@@ -92,7 +91,6 @@ export class CustomerDataApi extends BaseLoopBackApi {
     };
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -105,8 +103,6 @@ export class CustomerDataApi extends BaseLoopBackApi {
          * </em>
    *
    * @param {object} data Request data.
-   *
-   *  - `idToken` – `{string}` - 
    *
    *  - `modelName` – `{string}` - 
    *
@@ -121,14 +117,13 @@ export class CustomerDataApi extends BaseLoopBackApi {
    * This usually means the response is a `CustomerData` object.)
    * </em>
    */
-  public genericUpsert(idToken: any, modelName: any, modelObj: any, customHeaders?: Function): Observable<any> {
+  public genericUpsert(modelName: any, modelObj: any, customHeaders?: Function): Observable<any> {
     let _method: string = "PUT";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/CustomerData/upsert";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof modelObj !== 'undefined' && modelObj !== null) _urlParams.modelObj = modelObj;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -140,11 +135,11 @@ export class CustomerDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {string} id 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -152,7 +147,7 @@ export class CustomerDataApi extends BaseLoopBackApi {
    *
    * This method returns no data.
    */
-  public genericDestroyById(idToken: any, modelName: any, id: any, customHeaders?: Function): Observable<any> {
+  public genericDestroyById(modelName: any, id: any, customHeaders?: Function): Observable<any> {
     let _method: string = "DELETE";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/CustomerData/delete/:id";
@@ -161,7 +156,6 @@ export class CustomerDataApi extends BaseLoopBackApi {
     };
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
     return result;
@@ -173,8 +167,6 @@ export class CustomerDataApi extends BaseLoopBackApi {
          * </em>
    *
    * @param {object} data Request data.
-   *
-   *  - `idToken` – `{string}` - 
    *
    *  - `modelName` – `{string}` - 
    *
@@ -191,14 +183,13 @@ export class CustomerDataApi extends BaseLoopBackApi {
    * This usually means the response is a `CustomerData` object.)
    * </em>
    */
-  public genericMethod(idToken: any, modelName: any, methodName: any, params: any = {}, customHeaders?: Function): Observable<any> {
+  public genericMethod(modelName: any, methodName: any, params: any = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "POST";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/CustomerData/method";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof methodName !== 'undefined' && methodName !== null) _urlParams.methodName = methodName;
     if (typeof params !== 'undefined' && params !== null) _urlParams.params = params;

--- a/client/src/app/shared/sdk/services/custom/EmployeeData.ts
+++ b/client/src/app/shared/sdk/services/custom/EmployeeData.ts
@@ -32,11 +32,11 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {object} filter 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object[]} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -47,14 +47,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    * This usually means the response is a `EmployeeData` object.)
    * </em>
    */
-  public genericFind(idToken: any, modelName: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+  public genericFind(modelName: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "GET";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/find";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -66,13 +65,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {string} id 
    *
    * @param {object} filter 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -83,7 +82,7 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    * This usually means the response is a `EmployeeData` object.)
    * </em>
    */
-  public genericFindById(idToken: any, modelName: any, id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+  public genericFindById(modelName: any, id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "GET";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/findById/:id";
@@ -92,7 +91,6 @@ export class EmployeeDataApi extends BaseLoopBackApi {
     };
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -105,8 +103,6 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * </em>
    *
    * @param {object} data Request data.
-   *
-   *  - `idToken` – `{string}` - 
    *
    *  - `modelName` – `{string}` - 
    *
@@ -121,14 +117,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    * This usually means the response is a `EmployeeData` object.)
    * </em>
    */
-  public genericUpsert(idToken: any, modelName: any, modelObj: any, customHeaders?: Function): Observable<any> {
+  public genericUpsert(modelName: any, modelObj: any, customHeaders?: Function): Observable<any> {
     let _method: string = "PUT";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/upsert";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof modelObj !== 'undefined' && modelObj !== null) _urlParams.modelObj = modelObj;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
@@ -140,11 +135,11 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {string} id 
+   *
+   * @param {string} accessToken 
    *
    * @returns {object} An empty reference that will be
    *   populated with the actual data once the response is returned
@@ -152,7 +147,7 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    *
    * This method returns no data.
    */
-  public genericDestroyById(idToken: any, modelName: any, id: any, customHeaders?: Function): Observable<any> {
+  public genericDestroyById(modelName: any, id: any, customHeaders?: Function): Observable<any> {
     let _method: string = "DELETE";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/delete/:id";
@@ -161,7 +156,6 @@ export class EmployeeDataApi extends BaseLoopBackApi {
     };
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
     return result;
@@ -173,8 +167,6 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * </em>
    *
    * @param {object} data Request data.
-   *
-   *  - `idToken` – `{string}` - 
    *
    *  - `modelName` – `{string}` - 
    *
@@ -191,14 +183,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    * This usually means the response is a `EmployeeData` object.)
    * </em>
    */
-  public genericMethod(idToken: any, modelName: any, methodName: any, params: any = {}, customHeaders?: Function): Observable<any> {
+  public genericMethod(modelName: any, methodName: any, params: any = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "POST";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/method";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof methodName !== 'undefined' && methodName !== null) _urlParams.methodName = methodName;
     if (typeof params !== 'undefined' && params !== null) _urlParams.params = params;
@@ -211,13 +202,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
          * (The remote method definition does not provide any description.)
          * </em>
    *
-   * @param {string} idToken 
-   *
    * @param {string} modelName 
    *
    * @param {string} methodName 
    *
    * @param {any} params 
+   *
+   * @param {string} accessToken 
    *
    * @param {object} res 
    *
@@ -227,14 +218,13 @@ export class EmployeeDataApi extends BaseLoopBackApi {
    *
    * This method returns no data.
    */
-  public genericGetFile(idToken: any, modelName: any, methodName: any, params: any = {}, res: any = {}, customHeaders?: Function): Observable<any> {
+  public genericGetFile(modelName: any, methodName: any, params: any = {}, res: any = {}, customHeaders?: Function): Observable<any> {
     let _method: string = "GET";
     let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
     "/EmployeeData/file";
     let _routeParams: any = {};
     let _postBody: any = {};
     let _urlParams: any = {};
-    if (typeof idToken !== 'undefined' && idToken !== null) _urlParams.idToken = idToken;
     if (typeof modelName !== 'undefined' && modelName !== null) _urlParams.modelName = modelName;
     if (typeof methodName !== 'undefined' && methodName !== null) _urlParams.methodName = methodName;
     if (typeof params !== 'undefined' && params !== null) _urlParams.params = params;

--- a/common/models/end-user.js
+++ b/common/models/end-user.js
@@ -42,7 +42,7 @@ module.exports = function(EndUser) {
   const AllowedMethodsByRole = {
     customer: ['sendMeResetPasswordEmail', 'getMyUser', 'saveProductExclusionList'],
     manager: ['sendMeResetPasswordEmail'],
-    admin: ['sendMeResetPasswordEmail', 'getAuth0Logs']
+    admin: ['sendMeResetPasswordEmail', 'getLogs']
   };
 
   /**

--- a/common/models/end-user.js
+++ b/common/models/end-user.js
@@ -9,7 +9,7 @@ const auth0ManagementClient = require('auth0').ManagementClient;
 const tenantSettings = require(appRoot + '/config/tenant');
 const logger = require(appRoot + '/config/winston');
 const app = require(appRoot + '/server/server');
-const Auth0EventMap = require(appRoot + '/common/util/auth0-event-code-map');
+const Auth0Helper = require(appRoot + '/common/util/auth0-helper');
 
 module.exports = function(EndUser) {
   const CLIENT_ID = process.env.AUTH0_API_CLIENT_ID;
@@ -304,7 +304,8 @@ module.exports = function(EndUser) {
       logs = logs.concat(transformInstances(orders, 'Order', user.id));
       logs = logs.concat(transformInstances(statements, 'Statement', user.id));
       logs = logs.concat(auth0logs.map(log => {
-        let eventDesc = Auth0EventMap.get(log.type);
+        // let eventDesc = Auth0EventMap.get(log.type);
+        let eventDesc = Auth0Helper.getEventDescription(log.type);
         let fromLoc = _.get(log, ['location_info', 'city_name'], '') + '/' + _.get(log, ['location_info', 'country_code'], '');
         if (fromLoc !== '/') {
           eventDesc = eventDesc + ` (location: ${fromLoc})`;

--- a/server/boot/auth0-init.js
+++ b/server/boot/auth0-init.js
@@ -107,9 +107,11 @@ module.exports = async function(app) {
   const namespace = 'https://om.com/';
   if (user.user_metadata) {
     context.idToken[namespace + 'user_metadata'] = user.user_metadata;
+    context.accessToken[namespace + 'user_metadata'] = user.user_metadata;
   }
   if (user.app_metadata) {
     context.idToken[namespace + 'app_metadata'] = user.app_metadata;
+    context.accessToken[namespace + 'app_metadata'] = user.app_metadata;
   }
   callback(null, user, context);
 }`,

--- a/test/api-test/auth.js
+++ b/test/api-test/auth.js
@@ -23,16 +23,16 @@ describe('Public Content', function() {
 describe('Auth API', function() {
   it('should fail to access auth employee API', function(done) {
     api
-      .post('/api/EmployeeData/resetPassword')
-      .query({ idToken: 'invalid token' })
+      .get('/api/EmployeeData/find')
+      .query({ modelName: 'Order', filter: { limit: 1 } })
       .expect(401)
       .end(done);
   });
 
   it('should fail to access auth customer API', function(done) {
     api
-      .post('/api/CustomerData/resetPassword')
-      .query({ idToken: 'invalid token' })
+      .get('/api/CustomerData/find')
+      .query({ modelName: 'Order', filter: { limit: 1 } })
       .expect(401)
       .end(done);
   });


### PR DESCRIPTION
Remove idToken parameter from all exposed APIs. Instead user metadata is extracted from accessToken which is already included in the request header.
Refactored Auth0 related functions out of both EmployeeData and CustomerData models and into a separate helper module, auth0-helper.js.