### PR TITLE
Add fee_explanation column to order table.

### DIFF
--- a/client/src/app/modules/auth/modules/customer/components/orders/new-order/new-order.component.html
+++ b/client/src/app/modules/auth/modules/customer/components/orders/new-order/new-order.component.html
@@ -63,7 +63,7 @@
                 Subtotal: {{order.subtotal | currency}}
               </div>
               <div *ngIf="isFeeApplicable()">
-                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
+                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
                 </fa-icon>                  
               </div>
               <div style="background-color: #F5F5F5">
@@ -135,7 +135,7 @@
                 Subtotal: {{order.subtotal | currency}}
               </div>
               <div *ngIf="isFeeApplicable()">
-                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
+                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
                 </fa-icon>                  
               </div>
               <div style="background-color: #F5F5F5">

--- a/client/src/app/modules/auth/modules/customer/components/orders/new-order/new-order.component.ts
+++ b/client/src/app/modules/auth/modules/customer/components/orders/new-order/new-order.component.ts
@@ -36,6 +36,7 @@ export class NewOrderComponent implements OnInit {
       clientId: '',
       subtotal: 0,
       fee: 0,
+      feeExplanation: '',
       totalAmount: 0,
       note: null
     };
@@ -97,19 +98,6 @@ export class NewOrderComponent implements OnInit {
     return this._client && this._client.feeSchedule === 'Order';
   }
 
-  explainFee(): string {
-    let text = '';
-    if (this._client) {
-      if (this._client.feeType === 'Fixed') {
-        text = 'Fixed amount';
-      }
-      if (this._client.feeType === 'Rate') {
-        text = `$${this.order.subtotal.toFixed(2)} x ${this._client.feeValue}(%) = ${this.order.fee.toFixed(2)}`;
-      }
-    }
-    return text;
-  }
-
   async create() {
     try {
       let orderItems = this.orderItems.data
@@ -167,6 +155,7 @@ export class NewOrderComponent implements OnInit {
     }
     this.order.subtotal = newSubtotal;
     this.order.fee = this._calculateFee(newSubtotal);
+    this.order.feeExplanation = this._explainFee(this.order);
     this.order.totalAmount = newSubtotal + this.order.fee;
 
   }
@@ -182,6 +171,19 @@ export class NewOrderComponent implements OnInit {
       }
     }
     return newFee;
+  }
+
+  private _explainFee(order:any): string {
+    let text = '';
+    if (this.isFeeApplicable()) {
+      if (this._client.feeType === 'Fixed') {
+        text = 'Fixed amount';
+      }
+      if (this._client.feeType === 'Rate') {
+        text = `$${order.subtotal.toFixed(2)} x ${this._client.feeValue}(%) = ${order.fee.toFixed(2)}`;
+      }
+    }
+    return text;
   }
 
   private _setTableDataSource(orderItems: Array<OrderItem>) {

--- a/client/src/app/modules/auth/modules/customer/components/orders/order-detail/order-detail.component.html
+++ b/client/src/app/modules/auth/modules/customer/components/orders/order-detail/order-detail.component.html
@@ -95,8 +95,8 @@
                   Subtotal: {{order.subtotal | currency}}
                 </div>
                 <div *ngIf="isFeeApplicable()">
-                  Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
-                  </fa-icon>                  
+                  Fee: {{order.fee | currency}} <span *ngIf="order.feeExplanation"><fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
+                  </fa-icon></span>
                 </div>
                 <div style="background-color: #F5F5F5">
                   <h3><span style="font-weight: bold">TOTAL</span>: {{order.totalAmount | currency}}</h3>
@@ -171,8 +171,8 @@
                   Subtotal: {{order.subtotal | currency}}
                 </div>
                 <div *ngIf="isFeeApplicable()">
-                  Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
-                  </fa-icon>                  
+                  Fee: {{order.fee | currency}} <span *ngIf="order.feeExplanation"><fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
+                  </fa-icon></span>
                 </div>
                 <div style="background-color: #F5F5F5">
                   <h3><span style="font-weight: bold">TOTAL</span>: {{order.totalAmount | currency}}</h3>

--- a/client/src/app/modules/auth/modules/customer/components/orders/order-detail/order-detail.component.ts
+++ b/client/src/app/modules/auth/modules/customer/components/orders/order-detail/order-detail.component.ts
@@ -96,19 +96,6 @@ export class OrderDetailComponent implements OnInit {
     return this.order.client && this.order.client.feeSchedule === 'Order';
   }
 
-  explainFee(): string {
-    let text = '';
-    if (this.order.client) {
-      if (this.order.client.feeType == 'Fixed') {
-        text = 'Fixed amount';
-      }
-      if (this.order.client.feeType == 'Rate') {
-        text = `$${this.order.subtotal.toFixed(2)} x ${this.order.client.feeValue}(%) = ${this.order.fee.toFixed(2)}`;
-      }
-    }
-    return text;
-  }
-
   getEmailCreated() {
     return this.order.userCreated.email;
   }
@@ -235,6 +222,19 @@ export class OrderDetailComponent implements OnInit {
     return newFee;
   }
 
+  private _explainFee(order:any): string {
+    let text = '';
+    if (this.isFeeApplicable()) {
+      if (this.order.client.feeType === 'Fixed') {
+        text = 'Fixed amount';
+      }
+      if (this.order.client.feeType === 'Rate') {
+        text = `$${order.subtotal.toFixed(2)} x ${this.order.client.feeValue}(%) = ${order.fee.toFixed(2)}`;
+      }
+    }
+    return text;
+  }
+
   private _updateTotalAmount() {
     let newSubtotal = 0;
     for (let element of this.orderItems.data) {
@@ -242,6 +242,7 @@ export class OrderDetailComponent implements OnInit {
     }
     this.order.subtotal = newSubtotal;
     this.order.fee = this._calculateFee(newSubtotal);
+    this.order.feeExplanation = this._explainFee(this.order);
     this.order.totalAmount = this.order.subtotal + this.order.fee;
   }
 

--- a/client/src/app/modules/auth/modules/employee/components/dashboard/dashboard.component.html
+++ b/client/src/app/modules/auth/modules/employee/components/dashboard/dashboard.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutGap="10px">
+<div fxLayout="column" fxLayoutGap="20px">
   <app-todays-snapshots></app-todays-snapshots>
   <app-total-orders></app-total-orders>
   <div fxLayout="row wrap" fxLayoutGap="10px" fxLayoutAlign="center space-between">

--- a/client/src/app/modules/auth/modules/employee/components/orders/new-order/new-order.component.html
+++ b/client/src/app/modules/auth/modules/employee/components/orders/new-order/new-order.component.html
@@ -82,7 +82,7 @@
                 Subtotal: {{order.subtotal | currency}}
               </div>
               <div *ngIf="isFeeApplicable()">
-                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
+                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
                 </fa-icon>                  
               </div>
               <div style="background-color: #F5F5F5">
@@ -156,7 +156,7 @@
                 Subtotal: {{order.subtotal | currency}}
               </div>
               <div *ngIf="isFeeApplicable()">
-                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
+                Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
                 </fa-icon>                  
               </div>
               <div style="background-color: #F5F5F5">

--- a/client/src/app/modules/auth/modules/employee/components/orders/new-order/new-order.component.ts
+++ b/client/src/app/modules/auth/modules/employee/components/orders/new-order/new-order.component.ts
@@ -34,6 +34,7 @@ export class NewOrderComponent implements OnInit {
       subtotal: 0,
       fee: 0,
       totalAmount: 0,
+      feeExplanation: '',      
       note: null
     };
   }
@@ -101,19 +102,6 @@ export class NewOrderComponent implements OnInit {
     return this.selectedClient && this.selectedClient.feeSchedule === 'Order';
   }
 
-  explainFee(): string {
-    let text = '';
-    if (this.selectedClient) {
-      if (this.selectedClient.feeType == 'Fixed') {
-        text = 'Fixed amount';
-      }
-      if (this.selectedClient.feeType == 'Rate') {
-        text = `$${this.order.subtotal.toFixed(2)} x ${this.selectedClient.feeValue}(%) = ${this.order.fee.toFixed(2)}`;
-      }
-    }
-    return text;
-  }
-
   async create() {
     try {
       let orderItems = this.orderItems.data
@@ -172,6 +160,7 @@ export class NewOrderComponent implements OnInit {
     }
     this.order.subtotal = newSubtotal;
     this.order.fee = this._calculateFee(newSubtotal);
+    this.order.feeExplanation = this._explainFee(this.order);
     this.order.totalAmount = newSubtotal + this.order.fee;
   }
 
@@ -186,6 +175,19 @@ export class NewOrderComponent implements OnInit {
       }
     }
     return newFee;
+  }
+
+  private _explainFee(order:any): string {
+    let text = '';
+    if (this.isFeeApplicable()) {
+      if (this.selectedClient.feeType === 'Fixed') {
+        text = 'Fixed amount';
+      }
+      if (this.selectedClient.feeType === 'Rate') {
+        text = `$${order.subtotal.toFixed(2)} x ${this.selectedClient.feeValue}(%) = ${order.fee.toFixed(2)}`;
+      }
+    }
+    return text;
   }
 
   private _setTableDataSource(products: Array<OrderItem>) {

--- a/client/src/app/modules/auth/modules/employee/components/orders/order-detail/order-detail.component.html
+++ b/client/src/app/modules/auth/modules/employee/components/orders/order-detail/order-detail.component.html
@@ -96,8 +96,8 @@
               Subtotal: {{order.subtotal | currency}}
             </div>
             <div *ngIf="isFeeApplicable()">
-              Fee: {{order.fee | currency}} <fa-icon icon="question-circle" matTooltip="{{explainFee()}}" matTooltipPosition="right">
-              </fa-icon>                  
+              Fee: {{order.fee | currency}} <span *ngIf="order.feeExplanation"><fa-icon icon="question-circle" matTooltip="{{order.feeExplanation}}" matTooltipPosition="right">
+              </fa-icon></span>
             </div>
             <div style="background-color: #F5F5F5">
               <h3><span style="font-weight: bold">TOTAL</span>: {{order.totalAmount | currency}}</h3>

--- a/client/src/app/modules/auth/modules/employee/components/orders/order-detail/order-detail.component.ts
+++ b/client/src/app/modules/auth/modules/employee/components/orders/order-detail/order-detail.component.ts
@@ -78,19 +78,6 @@ export class OrderDetailComponent implements OnInit {
     return this.order.client && this.order.client.feeSchedule === 'Order';
   }
 
-  explainFee(): string {
-    let text = '';
-    if (this.order.client) {
-      if (this.order.client.feeType == 'Fixed') {
-        text = 'Fixed amount';
-      }
-      if (this.order.client.feeType == 'Rate') {
-        text = `$${this.order.subtotal.toFixed(2)} x ${this.order.client.feeValue}(%) = ${this.order.fee.toFixed(2)}`;
-      }
-    }
-    return text;
-  }
-
   getEmailCreated() {
     return this.order.userCreated.email;
   }
@@ -220,6 +207,19 @@ export class OrderDetailComponent implements OnInit {
     return newFee;
   }
 
+  private _explainFee(order:any): string {
+    let text = '';
+    if (this.isFeeApplicable()) {
+      if (this.order.client.feeType === 'Fixed') {
+        text = 'Fixed amount';
+      }
+      if (this.order.client.feeType === 'Rate') {
+        text = `$${order.subtotal.toFixed(2)} x ${this.order.client.feeValue}(%) = ${order.fee.toFixed(2)}`;
+      }
+    }
+    return text;
+  }
+
   private _updateTotalAmount() {
     let newSubtotal = 0;
     for (let element of this.orderItems.data) {
@@ -227,6 +227,7 @@ export class OrderDetailComponent implements OnInit {
     }
     this.order.subtotal = newSubtotal;
     this.order.fee = this._calculateFee(newSubtotal);
+    this.order.feeExplanation = this._explainFee(this.order);
     this.order.totalAmount = this.order.subtotal + this.order.fee;
   }
 

--- a/common/models/order.json
+++ b/common/models/order.json
@@ -41,6 +41,13 @@
     "fee": {
       "type": "number"
     },
+    "feeExplanation": {
+      "type": "string",
+      "description": "note on fee amount",
+      "postgresql": {
+        "columnName": "fee_explanation"
+      }
+    },
     "totalAmount": {
       "type": "number",
       "postgresql": {

--- a/database/create_tables.sql
+++ b/database/create_tables.sql
@@ -132,6 +132,7 @@ CREATE TABLE IF NOT EXISTS order_t
   status order_status DEFAULT 'Submitted',
   subtotal numeric DEFAULT 0,
   fee numeric DEFAULT 0,
+  fee_explanation text,
   total_amount numeric DEFAULT 0,
   note text,
   created_by integer REFERENCES end_user,

--- a/database/update_tables.sql
+++ b/database/update_tables.sql
@@ -13,3 +13,4 @@ ALTER TABLE metric ADD COLUMN IF NOT EXISTS filter_by_model_name text;
 ALTER TABLE client ADD COLUMN IF NOT EXISTS fee_schedule fee_schedule DEFAULT 'None';
 ALTER TABLE statement_t ADD COLUMN IF NOT EXISTS fee_amount numeric DEFAULT 0;
 ALTER TABLE client ADD COLUMN IF NOT EXISTS settings jsonb;
+ALTER TABLE order_t ADD COLUMN IF NOT EXISTS fee_explanation text;


### PR DESCRIPTION
Update UI for Order.feeExplanation.
This pull addresses issue #97 
Fee explanation is now saved in each order to preserve calculation even after client changes its fee structure.